### PR TITLE
Fix for EAGAIN being raised in ZMQConnection._readMultipart

### DIFF
--- a/txZMQ/connection.py
+++ b/txZMQ/connection.py
@@ -136,7 +136,7 @@ class ZmqConnection(object):
         """
         while True:
             self.recv_parts.append(self.socket.recv(constants.NOBLOCK))
-            if not self.socket.rcvmore:
+            if not self.socket.getsockopt(constants.RCVMORE):
                 result, self.recv_parts = self.recv_parts, []
 
                 return result


### PR DESCRIPTION
I was unable to get txZMQ to react to new messages. Debugging the issue showed that ZMQConnection._readMultipart raised an EAGAIN exception on every received message. It seems, on my installation (Ubuntu 11.10, ZeroMQ 2.1.9, pyzmq 2.1.9), socket.rcvmore is a method. Changing this to socket.getsockopt(constants.RCVMORE) or socket.rcvmore() made the unit tests pass. This patch uses getsockopt in case socket.rcvmore is a boolean in some other version of pyzmq.
