### PR TITLE
Fix premature use of port #37

### DIFF
--- a/examples/push_pull.py
+++ b/examples/push_pull.py
@@ -49,7 +49,7 @@ if options.mode == "push":
 
         reactor.callLater(1, produce)
 
-    reactor.callWhenRunning(produce)
+    reactor.callWhenRunning(reactor.callLater, 1, produce)
 else:
     s = ZmqPullConnection(zf, e)
 


### PR DESCRIPTION
- Calling callWhileRunning for produce causes the twisted Reactor
  to attempt to use the ZMQ bound port before it's made available,
  causing a "false" EAGAIN.
