### PR TITLE
Py3k

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,9 @@ install:
     - sudo apt-get install libzmq3-dev
     - pip install -r requirements.txt --use-mirrors
 script:
-    - [ -f $VIRTUAL_ENV/bin/trial ] && coverage run $VIRTUAL_ENV/bin/trial --reactor=$REACTOR txzmq
+    - "[ -f $VIRTUAL_ENV/bin/trial ] && coverage run $VIRTUAL_ENV/bin/trial --reactor=$REACTOR txzmq"
+    - >-
+        [ -f $VIRTUAL_ENV/bin/trial ] && coverage run $VIRTUAL_ENV/bin/trial --reactor=$REACTOR txzmq
     - pep8 --repeat txzmq
     - pyflakes txzmq
     - python examples/integration_test.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ install:
 script:
     - >-
         [ ! -f $VIRTUAL_ENV/bin/trial ] || coverage run $VIRTUAL_ENV/bin/trial --reactor=$REACTOR txzmq
+    - nosetests
     - pep8 --repeat txzmq
     - pyflakes txzmq
     - python examples/integration_test.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,8 @@ install:
     - sudo apt-get install libzmq3-dev
     - pip install -r requirements.txt --use-mirrors
 script:
-    - "[ -f $VIRTUAL_ENV/bin/trial ] && coverage run $VIRTUAL_ENV/bin/trial --reactor=$REACTOR txzmq"
     - >-
-        [ -f $VIRTUAL_ENV/bin/trial ] && coverage run $VIRTUAL_ENV/bin/trial --reactor=$REACTOR txzmq
+        [ ! -f $VIRTUAL_ENV/bin/trial ] || coverage run $VIRTUAL_ENV/bin/trial --reactor=$REACTOR txzmq
     - pep8 --repeat txzmq
     - pyflakes txzmq
     - python examples/integration_test.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,9 @@ python:
     - 2.6
     - 2.7
     - 3.3
+    - 3.4
     - pypy
+    - pypy3
 env:
     - REACTOR=select
     - REACTOR=epoll
@@ -22,5 +24,5 @@ notifications:
         - me@smira.ru
 matrix:
     allow_failures:
-        - python: 3.3
         - python: pypy
+        - python: pypy3

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,8 @@ install:
 script:
     - >-
         [ ! -f $VIRTUAL_ENV/bin/trial ] || coverage run $VIRTUAL_ENV/bin/trial --reactor=$REACTOR txzmq
-    - nosetests
+    - >-
+        [ -f $VIRTUAL_ENV/bin/trial ] || nosetests
     - pep8 --repeat txzmq
     - pyflakes txzmq
     - python examples/integration_test.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ install:
     - sudo apt-get install libzmq3-dev
     - pip install -r requirements.txt --use-mirrors
 script:
-    - coverage run $VIRTUAL_ENV/bin/trial --reactor=$REACTOR txzmq
+    - [ -f $VIRTUAL_ENV/bin/trial ] && coverage run $VIRTUAL_ENV/bin/trial --reactor=$REACTOR txzmq
     - pep8 --repeat txzmq
     - pyflakes txzmq
     - python examples/integration_test.py

--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -8,3 +8,4 @@
 * Alexander Else
 * David J. Felix
 * Vsevolod Novikov
+* Tim Tisdall

--- a/txzmq/compat.py
+++ b/txzmq/compat.py
@@ -1,0 +1,17 @@
+import sys
+
+PY3 = sys.version_info[0] == 3
+
+if PY3:  # pragma: no cover
+    binary_string_type = bytes
+else:  # pragma: no cover
+    binary_string_type = str
+
+if PY3:  # pragma: no cover
+    def is_nonstr_iter(v):
+        if isinstance(v, (str, bytes)):
+            return False
+        return hasattr(v, '__iter__')
+else:  # pragma: no cover
+    def is_nonstr_iter(v):
+        return hasattr(v, '__iter__')

--- a/txzmq/connection.py
+++ b/txzmq/connection.py
@@ -13,6 +13,9 @@ from twisted.internet.interfaces import IFileDescriptor, IReadDescriptor
 from twisted.python import log
 
 from zmq import zmq_version_info
+
+from txzmq.compat import is_nonstr_iter
+
 ZMQ3 = zmq_version_info()[0] >= 3
 
 
@@ -305,7 +308,7 @@ class ZmqConnection(object):
             message) or just str
         :type message: str or list of str
         """
-        if not hasattr(message, '__iter__'):
+        if not is_nonstr_iter(message):
             self.socket.send(message, constants.NOBLOCK)
         else:
             for m in message[:-1]:

--- a/txzmq/test/test_connection.py
+++ b/txzmq/test/test_connection.py
@@ -57,11 +57,11 @@ class ZmqConnectionTestCase(unittest.TestCase):
         s = ZmqTestSender(
             self.factory, ZmqEndpoint(ZmqEndpointType.connect, "inproc://#3"))
 
-        s.send('abcd')
+        s.send(b'abcd')
 
         def check(ignore):
             result = getattr(r, 'messages', [])
-            expected = [['abcd']]
+            expected = [[b'abcd']]
             self.failUnlessEqual(
                 result, expected, "Message should have been received")
 
@@ -80,11 +80,11 @@ class ZmqConnectionTestCase(unittest.TestCase):
         s = ZmqTestSender(
             self.factory, ZmqEndpoint(ZmqEndpointType.connect, "inproc://#1"))
 
-        s.send('abcd')
+        s.send(b'abcd')
 
         def check(ignore):
             result = getattr(r, 'messages', [])
-            expected = [['abcd']]
+            expected = [[b'abcd']]
             self.failUnlessEqual(
                 result, expected, "Message should have been received")
 
@@ -99,11 +99,11 @@ class ZmqConnectionTestCase(unittest.TestCase):
                                       "tcp://127.0.0.1:5555"))
 
         for i in range(100):
-            s.send(str(i))
+            s.send(str(i).encode())
 
         def check(ignore):
             result = getattr(r, 'messages', [])
-            expected = map(lambda i: [str(i)], range(100))
+            expected = [[str(i).encode()] for i in range(100)]
             self.failUnlessEqual(
                 result, expected, "Messages should have been received")
 
@@ -117,11 +117,11 @@ class ZmqConnectionTestCase(unittest.TestCase):
             self.factory, ZmqEndpoint(ZmqEndpointType.connect,
                                       "tcp://127.0.0.1:5555"))
 
-        s.send(["0" * 10000, "1" * 10000])
+        s.send([b'0' * 10000, b'1' * 10000])
 
         def check(ignore):
             result = getattr(r, 'messages', [])
-            expected = [["0" * 10000, "1" * 10000]]
+            expected = [[b'0' * 10000, b'1' * 10000]]
             self.failUnlessEqual(
                 result, expected, "Messages should have been received")
 

--- a/txzmq/test/test_pubsub.py
+++ b/txzmq/test/test_pubsub.py
@@ -65,16 +65,16 @@ class ZmqConnectionTestCase(unittest.TestCase):
             self.factory, ZmqEndpoint(ZmqEndpointType.connect,
                                       "ipc://test-sock"))
 
-        r.subscribe('tag')
+        r.subscribe(b'tag')
 
         def publish(ignore):
-            s.publish('xyz', 'different-tag')
-            s.publish('abcd', 'tag1')
-            s.publish('efgh', 'tag2')
+            s.publish(b'xyz', b'different-tag')
+            s.publish(b'abcd', b'tag1')
+            s.publish(b'efgh', b'tag2')
 
         def check(ignore):
             result = getattr(r, 'messages', [])
-            expected = [['tag1', 'abcd'], ['tag2', 'efgh']]
+            expected = [[b'tag1', b'abcd'], [b'tag2', b'efgh']]
             self.failUnlessEqual(
                 result, expected, "Message should have been received")
 
@@ -88,15 +88,15 @@ class ZmqConnectionTestCase(unittest.TestCase):
         s = ZmqPubConnection(self.factory, ZmqEndpoint(
             ZmqEndpointType.connect, "epgm://127.0.0.1;239.192.1.1:5556"))
 
-        r.subscribe('tag')
+        r.subscribe(b'tag')
 
         def publish(ignore):
-            s.publish('xyz', 'different-tag')
-            s.publish('abcd', 'tag1')
+            s.publish(b'xyz', b'different-tag')
+            s.publish(b'abcd', b'tag1')
 
         def check(ignore):
             result = getattr(r, 'messages', [])
-            expected = [['tag1', 'abcd']]
+            expected = [[b'tag1', b'abcd']]
             self.failUnlessEqual(
                 result, expected, "Message should have been received")
 
@@ -116,15 +116,15 @@ class ZmqConnectionTestCase(unittest.TestCase):
             self.factory,
             ZmqEndpoint(ZmqEndpointType.connect, "inproc://endpoint"))
 
-        r.subscribe('')
+        r.subscribe(b'')
 
         def publish(ignore):
-            s1.publish('111', 'tag1')
-            s2.publish('222', 'tag2')
+            s1.publish(b'111', b'tag1')
+            s2.publish(b'222', b'tag2')
 
         def check(ignore):
             result = getattr(r, 'messages', [])
-            expected = [['tag1', '111'], ['tag2', '222']]
+            expected = [[b'tag1', b'111'], [b'tag2', b'222']]
             self.failUnlessEqual(
                 sorted(result), expected, "Message should have been received")
 


### PR DESCRIPTION
Most of the code required no changes and most of the issues where simply with the tests.  The only exception was the test used to determine if a `message` was an iterable or a string in `ZmqConnection.send()` (in py3k it saw the `bytes` as an iterable and ran the wrong thing).

I looked over some of the tests that are skipped in my environment and I think I fixed those too (but am not able to run them to be absolutely sure).