### PR TITLE
Integrate message reading into twisted reactor loop

### DIFF
--- a/examples/integration_test.py
+++ b/examples/integration_test.py
@@ -51,4 +51,4 @@ def start():
 reactor.callWhenRunning(reactor.callLater, 1, start)
 
 reactor.run()
-sys.exit(exitCode)
+os._exit(exitCode)

--- a/txzmq/connection.py
+++ b/txzmq/connection.py
@@ -267,9 +267,8 @@ class ZmqConnection(object):
                 self.read_scheduled.cancel()
             self.read_scheduled = None
         if self._read_loop is None:
-            self._read_loop = task.cooperate(self._read_messages()).\
-                whenDone().\
-                addBoth(self._read_done)
+            self._read_loop = task.cooperate(self._read_messages())
+            self._read_loop.whenDone().addBoth(self._read_done)
 
     def _read_messages(self):
         while True:

--- a/txzmq/connection.py
+++ b/txzmq/connection.py
@@ -282,9 +282,8 @@ class ZmqConnection(object):
             try:
                 message = self._readMultipart()
             except error.ZMQError as e:
-                if e.errno == constants.EAGAIN:
-                    pass
-                raise
+                if e.errno != constants.EAGAIN:
+                    raise
             else:
                 log.callWithLogger(self, self.messageReceived, message)
             yield

--- a/txzmq/connection.py
+++ b/txzmq/connection.py
@@ -206,6 +206,8 @@ class ZmqConnection(object):
         if self.read_scheduled is not None:
             self.read_scheduled.cancel()
             self.read_scheduled = None
+        if self._read_loop is not None:
+            self._read_loop.stop()
 
     def __repr__(self):
         return "%s(%r, %r)" % (


### PR DESCRIPTION
During work with txZMQ I met the case when fast incoming messages stream with not so fast message processing functions prevents twisted reactor's loop from resuming because loop reading messages in ``doRead()`` never ends - there are always new messages arrived. This pull request transforms message reading and processing loop to cooperative task scheduled by Twisted.