### PR TITLE
Use io.open when reading UTF-8 encoded file for Python3 compatibility.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,14 +1,16 @@
+import io
+
 from distutils.core import setup
 
 setup(
     name='txZMQ',
-    version=open('VERSION').read().strip(),
+    version=io.open('VERSION', encoding='utf-8').read().strip(),
     packages=['txzmq', 'txzmq.test'],
     license='GPLv2',
     author='Andrey Smirnov',
     author_email='me@smira.ru',
     url='https://github.com/smira/txZMQ',
     description='Twisted bindings for ZeroMQ',
-    long_description=open('README.rst').read(),
+    long_description=io.open('README.rst', encoding='utf-8').read(),
     install_requires=["Twisted>=10.0", "pyzmq>=13"],
 )


### PR DESCRIPTION
This way both Python2 and Python3 can use setup.py to handle the package.