### PR TITLE
Proper DelayedCall cleanup on `sendMsg`

### DIFF
--- a/txzmq/req_rep.py
+++ b/txzmq/req_rep.py
@@ -79,7 +79,10 @@ class ZmqREQConnection(ZmqConnection):
         @param msgId: message ID to cancel
         @type msgId: C{str}
         """
-        self._requests.pop(msgId, (None, None))
+        _, canceller = self._requests.pop(msgId, (None, None))
+
+        if canceller is not None and canceller.active():
+            canceller.cancel()
 
     def _timeoutRequest(self, msgId):
         """

--- a/txzmq/test/test_reqrep.py
+++ b/txzmq/test/test_reqrep.py
@@ -124,6 +124,21 @@ class ZmqREQREPConnectionTestCase(unittest.TestCase):
             .addCallback(check_requests) \
             .addCallback(lambda _: _wait(0.01))
 
+    def test_cancel_with_timeout(self):
+        d = self.s.sendMsg(b'aaa', timeout = 10.0)
+        d.cancel()
+
+        def check_requests(_):
+            self.assertEqual(self.s._requests, {})
+            self.failUnlessEqual(self.s.UUID_POOL_GEN_SIZE,
+                                 len(self.s._uuids) + 1)
+
+        return d.addCallbacks(lambda _: self.fail("Should have errored"),
+                              lambda fail: fail.trap(
+                              "twisted.internet.defer.CancelledError")) \
+            .addCallback(check_requests) \
+            .addCallback(lambda _: _wait(0.01))
+
     def test_send_timeout_ok(self):
         return self.s.sendMsg(b'aaa', timeout=0.1).addCallback(
             lambda response: self.assertEquals(response, [b'aaa'])

--- a/txzmq/test/test_reqrep.py
+++ b/txzmq/test/test_reqrep.py
@@ -125,7 +125,7 @@ class ZmqREQREPConnectionTestCase(unittest.TestCase):
             .addCallback(lambda _: _wait(0.01))
 
     def test_cancel_with_timeout(self):
-        d = self.s.sendMsg(b'aaa', timeout = 10.0)
+        d = self.s.sendMsg(b'aaa', timeout=10.0)
         d.cancel()
 
         def check_requests(_):


### PR DESCRIPTION
The `delayedCall` created by `ZmqREQConnection.sendMsg()` is not cleaned up properly when it is created with a timeout, and subsequently `cancel()`-ed.