### PR TITLE
Fix REQ/REP initialization of variables

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,9 @@ language: python
 sudo: false
 python:
     - 2.7
-    - 3.4
     - 3.5
     - 3.6
+    - 3.7
     - pypy
     - pypy3
 env:
@@ -21,7 +21,7 @@ script:
         [ ! -f $VIRTUAL_ENV/bin/trial ] || PYTHONPATH=. coverage run $VIRTUAL_ENV/bin/trial --reactor=$REACTOR txzmq
     - >-
         [ -f $VIRTUAL_ENV/bin/trial ] || PYTHONPATH=. nosetests
-    - pep8 --repeat txzmq
+    - pycodestyle --repeat txzmq
     - pyflakes txzmq
     - python examples/integration_test.py
 after_success:

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ env:
 env-clean: clean env
 
 check: env
-	env/bin/pep8 --repeat txzmq
+	env/bin/pycodestyle --repeat txzmq
 	env/bin/pyflakes txzmq
 
 check-clean: clean check

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
 Twisted
+service_identity
 pyzmq>=13
 pyflakes
-pep8
+pycodestyle
 Sphinx
 coverage
 coveralls

--- a/txzmq/req_rep.py
+++ b/txzmq/req_rep.py
@@ -41,9 +41,10 @@ class ZmqREQConnection(ZmqConnection):
     UUID_POOL_GEN_SIZE = 5
 
     def __init__(self, *args, **kwargs):
-        ZmqConnection.__init__(self, *args, **kwargs)
         self._requests = {}
         self._uuids = []
+
+        ZmqConnection.__init__(self, *args, **kwargs)
 
     def _getNextId(self):
         """
@@ -209,7 +210,7 @@ class ZmqXREPConnection(ZmqREPConnection):
                       "either ZmqREPConnection or ZmqROUTERConnection",
                       DeprecationWarning)
         ZmqREPConnection.__init__(self, factory)
-        self.add_endpoints(endpoints)
+        self.addEndpoints(endpoints)
 
 
 class ZmqXREQConnection(ZmqREQConnection):
@@ -225,4 +226,4 @@ class ZmqXREQConnection(ZmqREQConnection):
                       "either ZmqREQConnection or ZmqDEALERConnection",
                       DeprecationWarning)
         ZmqREQConnection.__init__(self, factory)
-        self.add_endpoints(endpoints)
+        self.addEndpoints(endpoints)

--- a/txzmq/test/test_reactor_shutdown.py
+++ b/txzmq/test/test_reactor_shutdown.py
@@ -38,4 +38,5 @@ class ZmqReactorShutdownTestCase(ReactorBuilder):
         reactor.callWhenRunning(_test)
         reactor.run()
 
+
 globals().update(ZmqReactorShutdownTestCase.makeTestCaseClasses())


### PR DESCRIPTION
Fixes #79

ZmqConnection.__init__ adds connection to the read loop, so it might
receive any kind of data before method returns.