### PR TITLE
Switch to setuptools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 import io
 
-from distutils.core import setup
+from setuptools import setup
 
 setup(
     name='txZMQ',


### PR DESCRIPTION
distutils itself [recommends using setuptools](https://docs.python.org/3/library/distutils.html).  Also of note, making this change will include dependency information in the egg metadata, which is used by third party tooling such as [Fedora's automatic dependency generator for Python RPM packages](https://docs.fedoraproject.org/en-US/packaging-guidelines/Python/#_automatically_generated_dependencies).