### PR TITLE
Allow topicSeparator to be changed

### DIFF
--- a/txzmq/connection.py
+++ b/txzmq/connection.py
@@ -66,6 +66,7 @@ class ZmqConnection(object):
     :vartype multicastRate: int
     :var highWaterMark: hard limit on the maximum number of outstanding
         messages 0MQ shall queue in memory for any single peer
+    :var topicSep: bytes
     :vartype highWaterMark: int
     :var tcpKeepalive: if set to 1, enable TCP keepalive, otherwise leave
         it as default
@@ -99,6 +100,7 @@ class ZmqConnection(object):
     allowLoopbackMulticast = False
     multicastRate = 100
     highWaterMark = 0
+    topicSep = b'\0'
 
     # Only supported by zeromq3 and pyzmq>=2.2.0.1
     tcpKeepalive = 0

--- a/txzmq/pubsub.py
+++ b/txzmq/pubsub.py
@@ -23,7 +23,11 @@ class ZmqPubConnection(ZmqConnection):
         :param tag: message tag
         :type tag: str
         """
-        self.send(tag + b'\0' + message)
+        if isinstance(tag, str):
+            tag = tag.encode()
+        if isinstance(message, str):
+            message = message.encode()
+        self.send(tag + self.topicSep + message)
 
 
 class ZmqSubConnection(ZmqConnection):
@@ -44,7 +48,7 @@ class ZmqSubConnection(ZmqConnection):
         :param tag: message tag
         :type tag: str
         """
-        self.socket.set(constants.SUBSCRIBE, tag)
+        self.socket.setsockopt(constants.SUBSCRIBE, tag)
 
     def unsubscribe(self, tag):
         """
@@ -55,7 +59,7 @@ class ZmqSubConnection(ZmqConnection):
         :param tag: message tag
         :type tag: str
         """
-        self.socket.set(constants.UNSUBSCRIBE, tag)
+        self.socket.setsockopt(constants.UNSUBSCRIBE, tag)
 
     def messageReceived(self, message):
         """
@@ -71,7 +75,7 @@ class ZmqSubConnection(ZmqConnection):
             # of multi-part message
             self.gotMessage(message[1], message[0])
         else:
-            self.gotMessage(*reversed(message[0].split(b'\0', 1)))
+            self.gotMessage(*reversed(message[0].split(self.topicSep, 1)))
 
     def gotMessage(self, message, tag):
         """


### PR DESCRIPTION
I really like this library, my only issue is that we need pub/sub payloads to be formatted `[Topic, 'b\0', Message]`. Would you be willing to allow this functionality to change so that I could call something like `ZmqPubConnection.topicSeparator = b'new_sep'`?