### PR TITLE
docs: fix simple typo, recevied -> received

### DIFF
--- a/txzmq/pubsub.py
+++ b/txzmq/pubsub.py
@@ -75,7 +75,7 @@ class ZmqSubConnection(ZmqConnection):
 
     def gotMessage(self, message, tag):
         """
-        Called on incoming message recevied by subscriber.
+        Called on incoming message received by subscriber.
 
         Should be overridden to handle incoming messages.
 


### PR DESCRIPTION
There is a small typo in txzmq/pubsub.py.

Should read `received` rather than `recevied`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md